### PR TITLE
Add contribution guide and collaboration templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,48 @@
+name: Bug report
+description: Report a reproducible problem or regression
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report an issue. Please provide as much detail as possible.
+  - type: input
+    id: summary
+    attributes:
+      label: Short summary
+      placeholder: Briefly describe the bug
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the exact steps to reproduce the behaviour
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: FinMLKit version
+      placeholder: e.g. 0.1.10
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any error messages or stack traces
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+blank_issues_enabled: false
+defaults:
+  assignees: []
+  labels: []

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,0 +1,26 @@
+name: Documentation update
+description: Suggest improvements or report gaps in docs
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us keep documentation accurate and helpful.
+  - type: input
+    id: section
+    attributes:
+      label: Documentation section
+      placeholder: e.g. README, API reference
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: What should be added or changed?
+    validations:
+      required: true
+  - type: textarea
+    id: suggestions
+    attributes:
+      label: Proposed text or examples

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,0 +1,30 @@
+name: Enhancement idea
+description: Improve existing functionality or performance
+labels: [improvement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share your idea for enhancing current features, APIs, or performance.
+  - type: input
+    id: area
+    attributes:
+      label: Area to improve
+      placeholder: Which part of the project?
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Suggested approach
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Impact or benchmarks

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest a new idea for FinMLKit
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a feature in mind? Describe it below to start the conversation.
+  - type: input
+    id: summary
+    attributes:
+      label: Feature summary
+      placeholder: Briefly describe the feature
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this feature useful?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Outline how you plan to implement it
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/ISSUE_TEMPLATE/testing.yaml
+++ b/.github/ISSUE_TEMPLATE/testing.yaml
@@ -1,0 +1,26 @@
+name: Testing improvement
+description: Improve test coverage or report failing tests
+labels: [testing]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for issues related to tests or continuous integration.
+  - type: input
+    id: area
+    attributes:
+      label: Affected module
+      placeholder: Which part of the codebase?
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem description
+      description: What test fails or what coverage is missing?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed tests or fixes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+- _Provide a concise description of your changes._
+
+## Related Issues
+- Closes #
+
+## Testing
+- [ ] `NUMBA_DISABLE_JIT=1 pytest -q`
+- [ ] Other (please describe)
+
+## Documentation
+- [ ] Added/updated docstrings
+- [ ] Updated README or other docs
+
+## Checklist
+- [ ] Tests added or updated
+- [ ] Documentation added or updated
+- [ ] Linting and type checks pass

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS Instructions
+
+- Use `rg` for searching instead of `grep -R` or `ls -R`.
+- Install the package in editable mode with `pip install -e .` before running tests.
+- Run the test suite from the project root.
+- For full test runs, disable Numba JIT: `NUMBA_DISABLE_JIT=1 pytest -q`.
+- Helper scripts: `./local_test.sh` (JIT enabled) and `./local_test_nojit.sh` (JIT disabled).
+- See `tests/README.md` for detailed testing guidance and troubleshooting.
+- Keep commits focused and leave the working tree clean before calling `make_pr`.

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -1,0 +1,66 @@
+# Contribution Guide
+
+FinMLKit thrives on community involvement. We value **contribution**, **transparency**, **documentation**, and **thorough testing**. This guide explains how to get started and how to make your contribution count.
+
+## Core Principles
+- **Open Collaboration** – we welcome ideas, questions and improvements from everyone.
+- **Transparency** – discussions, design decisions and code should be easy to follow.
+- **Documentation First** – every feature or change should include clear docs and examples.
+- **Test Rigorously** – changes must include tests that cover success and failure cases.
+
+## Getting Started
+1. Fork the repository and clone your fork.
+2. Install the package in editable mode:
+   ```bash
+   pip install -e .
+   ```
+3. Install development dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Create a new branch for your work. *(Avoid pushing to `main` directly).* 
+
+## How to Contribute
+Choose the path that matches your idea:
+
+### 🐞 Bug Fixes
+- Check existing issues to avoid duplication.
+- Write a failing test that reproduces the bug.
+- Fix the bug and ensure tests pass.
+
+### 🌱 New Features
+- Open an issue to discuss the idea before coding.
+- Provide minimal, well-documented APIs.
+- Include usage examples in the documentation and tests.
+
+### 🔧 Enhancements
+- Propose improvements to existing functionality in an issue.
+- Keep backward compatibility in mind.
+
+### 📚 Documentation Improvements
+- Improve docstrings, tutorials, or README sections.
+- Follow the reStructuredText style used throughout the project.
+
+### 🧪 Testing
+- Add or expand tests for any change.
+- Run the test suite from the project root. For a full run, disable JIT:
+  `NUMBA_DISABLE_JIT=1 pytest -q`.
+- Refer to [tests/README.md](tests/README.md) for details and helper scripts
+  (`./local_test.sh` and `./local_test_nojit.sh`).
+
+## Coding Standards
+- Follow [PEP 8](https://peps.python.org/pep-0008/) and existing project style.
+- Use descriptive commit messages and keep commits focused.
+- Typing is encouraged; prefer explicit type hints.
+
+## Pull Request Process
+1. Ensure your branch is up to date with `main`.
+2. Run tests locally: `NUMBA_DISABLE_JIT=1 pytest -q` (see [tests/README.md](tests/README.md)).
+3. Update documentation and include examples as needed.
+4. Fill out the PR template, describing the change and any breaking behaviour.
+5. Link relevant issues in the PR description.
+
+## Community
+Questions or ideas? Open an issue or start a discussion. Respectful communication is expected at all times.
+
+Thank you for helping make FinMLKit better!

--- a/README.md
+++ b/README.md
@@ -150,8 +150,21 @@ By ensuring that the algorithms are well-documented, with clear references to th
 **FinMLKit** is designed to be **well-documented**, with detailed explanations of each algorithm, method, and function. It uses `reStructured` style docstrings to provide clear and concise documentation for each function, class, and module. This makes it easier for users to understand how to use the library and what each function does. It uses `Sphinx` to generate the documentation and automatically deploy it to [finmlkit.readthedocs.io](https://finmlkit.readthedocs.io/en/latest/). This way, users can access the documentation online and easily navigate through the library's features and functionalities. This framework also enables the creation of tutorials or in-depth descriptions of the methods.
 
 # 🤝 Contribution
-We aim to make **FinMLKit** as easy to contribute to as possible. Whether it’s fixing bugs, adding new features, 
+We aim to make **FinMLKit** as easy to contribute to as possible. Whether it’s fixing bugs, adding new features,
 or improving documentation, **your contribution matters**. Let’s work together to make the common ground for financial machine learning!
+
+See [CONTRIBUTION.md](CONTRIBUTION.md) for detailed guidelines on bug reports, new features, enhancements, documentation, and testing.
+
+## 🧪 Testing
+To run the full test suite locally, disable Numba's JIT compiler:
+
+```bash
+NUMBA_DISABLE_JIT=1 pytest -q
+```
+
+Alternatively, use the helper scripts `./local_test.sh` (JIT enabled) or
+`./local_test_nojit.sh` (JIT disabled). See [tests/README.md](tests/README.md)
+for more guidance.
 
 **Star** the repo, **cite** it in your work, file issues, propose features, and share benchmark results. Let’s make **better defaults** the norm.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,11 +1,16 @@
 # Tests
 
-Testing is done using the `pytest` framework. 
+Testing is done using the `pytest` framework. Install the package in
+editable mode with development dependencies before running tests:
+
+```bash
+pip install -e .[dev]
+```
 
 > [!CAUTION]
 > Note that **testing numba function** are often **tricky and challenging**. I recommend to first disable jit and debug the code in pure python. If that passes, then re-enable jit and run the tests again. Both ways should pass. 
 
-You can disable jit by setting the environment variable `NUMBA_DISABLE_JIT=1`.
+You can disable JIT by setting the environment variable `NUMBA_DISABLE_JIT=1`.
 ```python test_my_testfile.py
 # test_my_testfile.py
 import os
@@ -17,19 +22,19 @@ from finmlkit.utils import my_numba_fn
 ```
 After you are done, it is important to **re-enable jit** by removing or commenting out the above code (otherwise it can broke the full test pipeline if numba disabling stays there) 
 
-Alternatively, simply run the test with `NUMBA_DISABLE_JIT=1 pytest`.
+Alternatively, run the entire suite with `NUMBA_DISABLE_JIT=1 pytest`.
 
-For convenience, we created bash scripts to create a fresh virtual test environment and run all tests with and without jit enabled.
+For convenience, bash scripts are provided to create a fresh virtual test
+environment and run all tests with and without JIT enabled.
 
-To run all tests with jit enabled, you can use the following script in the root directory of the project:
+Run these from the project root:
+
 ```bash
-chmode +x ../local_test.sh
-../local_test.sh
-```
-To run all tests with jit disabled, you can use the following command:
-```bash
-chmod +x ../local_test_nojit.sh
-../local_test_nojit.sh
+chmod +x local_test.sh
+./local_test.sh          # JIT enabled
+
+chmod +x local_test_nojit.sh
+./local_test_nojit.sh    # JIT disabled
 ```
 
 >[!IMPORTANT]


### PR DESCRIPTION
## Summary
- add CONTRIBUTION.md explaining core principles and contribution workflow
- add issue templates and pull request template to improve collaboration
- document testing process via AGENTS instructions, README and templates
- link contribution guide from README and reference tests/README

## Testing
- `NUMBA_DISABLE_JIT=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689733802b4083288cf504eca154bb26